### PR TITLE
Alternative Trias link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Got any more info, details, links? Please don't hesitate to open an issue and/or
 - [`EFA`](http://efa.vvo-online.de:8080)
   - "Classic" interface for trip requests
   - No known (public) documentation (yet?)
-- [`Trias`](http://trias.vvo-online.de:9000/middleware/data/trias)
+- [`Trias`](http://trias.vvo-online.de:9000/middleware/data/trias) or [`here`](http://efa.vvo-online.de:8080/std3/trias)
   - Brand new and still in the process of being implemented afaik
   - "Documentation" [here](https://www.vdv.de/431-2sds-v1.1.pdfx?forced=true)
 - [`DVB WebDFI`](http://dfi.dvb.de/)


### PR DESCRIPTION
At least for me the given trias link from README.md didn't work. I've found a second instance mentioned [here](https://www.govdata.de/web/guest/daten/-/details/api-fahrplanauskunft-vvo) and added it to the readme. Maybe the whole instance was moved there.

Apparently the trias api is not very well documented, are there any known apps that use it? I would really enjoy reverse engineering the api.